### PR TITLE
Fixed a "grumbronze" typo causing the Trimmed mod to crash during mod loading

### DIFF
--- a/src/main/resources/assets/trimmed/maps/unchecked/custom_trim_material_permutations.json
+++ b/src/main/resources/assets/trimmed/maps/unchecked/custom_trim_material_permutations.json
@@ -8,6 +8,6 @@
     "mythictinkers:trims/color_palettes/element_122": "mythictinkers_element_122",
     "mythictinkers:trims/color_palettes/aurichalcum": "mythictinkers_aurichalcum",
     "mythictinkers:trims/color_palettes/prosprum": "mythictinkers_prosprum",
-    "mythictinkers:trims/color_palettes/grumbronze": "mythictinkers_gumbronze"
+    "mythictinkers:trims/color_palettes/gumbronze": "mythictinkers_gumbronze"
   }
 }


### PR DESCRIPTION
I commented this under issues, and I had the wrong information then, but I discovered I had the typo and the correct one backwards.  I fixed the actual typo, and I tested it by loading the mod with Trimmed, then making a diamond chest piece with a gum bronze trim, and it appeared to work correctly! :)